### PR TITLE
PY-WEEK-1: implement active users finder taking in two files

### DIFF
--- a/active_users/active_users_finder.py
+++ b/active_users/active_users_finder.py
@@ -1,0 +1,44 @@
+import sys
+
+
+def read_file(filename):
+    data = {}
+    with open(filename, 'r') as file:
+        next(file)
+        for line in file:
+            parts = line.strip().split()
+            if len(parts) >= 2:
+                data[parts[0]] = parts[1]
+            else:
+                print(f"Error: Line '{line.strip()}' in file '{filename}' has fewer elements than expected.")
+    return data
+
+
+def format_output(fileA_data, fileB_data):
+    output = []
+    for username, status in fileB_data.items():
+        if status.lower() == "yes":
+            email = username.split('@')[1]
+            if email.startswith('yaboo'):
+                if username in fileA_data:
+                    output.append(f"{username} ({fileA_data[username]})")
+                else:
+                    output.append(f"{username} (444) 123-1233")
+    return output
+
+
+def main(fileA, fileB):
+    fileA_data = read_file(fileA)
+    fileB_data = read_file(fileB)
+    output = format_output(fileA_data, fileB_data)
+    for line in output:
+        print(line)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python active_users_finder.py fileA fileB")
+        sys.exit(1)
+    fileA = sys.argv[1]
+    fileB = sys.argv[2]
+    main(fileA, fileB)

--- a/active_users/active_users_finder.py
+++ b/active_users/active_users_finder.py
@@ -18,12 +18,13 @@ def format_output(fileA_data, fileB_data):
     output = []
     for username, status in fileB_data.items():
         if status.lower() == "yes":
-            email = username.split('@')[1]
-            if email.startswith('yaboo'):
-                if username in fileA_data:
-                    output.append(f"{username} ({fileA_data[username]})")
-                else:
-                    output.append(f"{username} (444) 123-1233")
+            if '@' in username:
+                email = username.split('@')[1]
+                if email.startswith('yaboo'):
+                    if username in fileA_data:
+                        output.append(f"{username} ({fileA_data[username]})")
+                    else:
+                        output.append(f"{username} (444) 123-1233")
     return output
 
 


### PR DESCRIPTION
Problem Statement:

You are working in yaboo and need to find out the active users and their phone numbers
You are given:
FileA that contains a list of email address and phone numbers:
lpalmer@hotmail.com (258) 549-4757
improv@me.com (609) 913-7355
augusto@aol.com (592) 654-7131
arathi@aol.com (634) 354-4918
oevans@yaboo.ca (742) 981-4153
payned@outlook.com (839) 287-8645
dwsauder@yaboo.com (838) 224-4554
hermes@att.net (318) 532-5452
tattooman@outlook.com (825) 548-2531
moxfulder@msn.com (507) 661-5659
ganter@mac.com (828) 940-9569
william@att.net (366) 905-7677
thomasj@me.com (656) 883-1111
birddog@yaboo.ca (656) 883-9559
geeber@live.com (970) 948-1231
chrisj@yaboo.com (241) 975-9057
mccurley@yahoo.com (317) 580-6330
 
FileB that contains usernames and their status
Username IsActive
dwsauder Yes
birddog No
jjlee Yes
oevans Yes
chrisj No
mccurley No
lchin Yes
 
if active users not not found in FileA, you use your company main line number (444) 123-1233
 
input: FileA, FileB
output: active users and their phone numbers in format
username (xxx) xxx-xxxx